### PR TITLE
Add a JIT stats tracking library 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,28 @@
 ﻿Our original code is licensed on a per-file basis. Other project's licenses
 are included below for reference.
 
+--[[ luatrace License ]]-------------------------------------------
+
+Copyright (c) 2011 Incremental IP Limited
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
 --[[ ZeroBrane Studio License ]]-------------------------------------------
 
 ZeroBrane Studio sources are released under the MIT License

--- a/jitstats.lua
+++ b/jitstats.lua
@@ -1,0 +1,448 @@
+local jit = require("jit")
+local bc = require("jit.bc")
+local vmdef = require("jit.vmdef")
+local jutil = jit.util or require("jit.util")
+local funcinfo, funcbc = jutil.funcinfo, jutil.funcbc
+local band = bit.band
+require("table.clear")
+require("table.new")
+
+local bcnames, bcname_lookup = {}, {} 
+local bccount = 0
+for i = 0, #vmdef.bcnames-1, 6 do
+    local name = string.sub(vmdef.bcnames, i, i+6):match "^%s*(.-)%s*$"
+    bcnames[bccount] = name
+    bcname_lookup[name] = bccount
+    bccount = bccount + 1
+end
+
+local traceerr_lookup = {}
+for i, msg in pairs(vmdef.traceerr) do
+    traceerr_lookup[msg] = i
+end
+
+local traceerror_info = {
+  {name = "RECERR",  msg = "error thrown or hook called during recording"},
+  {name = "TRACEUV", msg = "trace too short"},
+  {name = "TRACEOV", msg = "trace too long"},
+  {name = "STACKOV", msg = "trace too deep"},
+  {name = "SNAPOV",  msg = "too many snapshots"},
+  {name = "BLACKL",  msg = "blacklisted", displaymsg = "Function or loop blacklisted"},
+  {name = "RETRY",   msg = "retry recording"},
+  {name = "NYIBC",   msg = "NYI: bytecode %d", displaymsg = "NYI: bytecode"},
+  
+  -- Recording loop ops.
+  {name = "LLEAVE",  msg = "leaving loop in root trace"},
+  {name = "LINNER",  msg = "inner loop in root trace"},
+  {name = "LUNROLL", msg = "loop unroll limit reached"},
+  
+  -- Recording calls/returns.
+  {name = "BADTYPE", msg = "bad argument type"},
+  {name = "CJITOFF", msg = "JIT compilation disabled for function"},
+  {name = "CUNROLL", msg = "call unroll limit reached"},
+  {name = "DOWNREC", msg = "down-recursion, restarting"},
+  {name = "NYIFFU",  msg = "NYI: unsupported variant of FastFunc %s", displaymsg = "NYI: unsupported variant of FastFunc"},
+  {name = "NYIRETL", msg = "NYI: return to lower frame"},
+  
+  -- Recording indexed load/store.
+  {name = "STORENN", msg = "store with nil or NaN key"},
+  {name = "NOMM",    msg = "missing metamethod"},
+  {name = "IDXLOOP", msg = "looping index lookup"},
+  {name = "NYITMIX", msg = "NYI: mixed sparse/dense table"},
+  
+  -- Recording C data operations. */
+  {name = "NOCACHE", msg = "symbol not in cache"},
+  {name = "NYICONV", msg = "NYI: unsupported C type conversion"},
+  {name = "NYICALL", msg = "NYI: unsupported C function type"},
+  
+  -- Optimizations.
+  {name = "GFAIL",   msg = "guard would always fail"},
+  {name = "PHIOV",   msg = "too many PHIs"},
+  {name = "TYPEINS", msg = "persistent type instability"},
+  
+  -- Assembler.
+  {name = "MCODEAL", msg = "failed to allocate mcode memory"},
+  {name = "MCODEOV", msg = "machine code too long"},
+  {name = "MCODELM", msg = "hit mcode limit (retrying)"},
+  {name = "SPILLOV", msg = "too many spill slots"},
+  {name = "BADRA",   msg = "inconsistent register allocation"},
+  {name = "NYIIR",   msg = "NYI: cannot assemble IR instruction %d"},
+  {name = "NYIPHI",  msg = "NYI: PHI shuffling too complex"},
+  {name = "NYICOAL", msg = "NYI: register coalescing too complex"},
+}
+
+local traceerr = {}
+local traceerr_fromid = table.new(#vmdef.traceerr, 0)
+local traceerr_displaymsg = {}
+
+for i, evt in ipairs(traceerror_info) do
+    local id = traceerr_lookup[evt.msg]
+    if id then
+        traceerr[evt.name] = id
+        traceerr_fromid[id] = evt.name
+    end
+    traceerr_displaymsg[evt.name] = evt.displaymsg or evt.msg
+end
+
+local function printf(fmt, ...)
+    print(string.format(fmt, ...))
+end
+
+local debugprint = function () end
+
+local function fmtfunc(func, pc)
+    local fi = funcinfo(func, pc)
+    if fi.loc then
+        return fi.loc
+    elseif fi.ffid then
+        return vmdef.ffnames[fi.ffid]
+    elseif fi.addr then
+        return string.format("C:%x", fi.addr)
+    else
+        return "(?)"
+    end
+end
+
+-- Format trace error message.
+local function fmterr(err, info)
+    if type(err) == "number" then
+        if type(info) == "function" then
+          info = fmtfunc(info) 
+        end
+        err = string.format(vmdef.traceerr[err], info)
+    end
+    return err
+end
+
+local jitstats = {
+    isrunning = false,
+    debug = false,
+    stats = {}
+}
+
+local stats = jitstats.stats
+
+local vmevent = {}
+
+local curr_parentid, curr_stitched
+-- Trace started
+function vmevent.start(tr, func, pc, parentid, exitnum)
+    curr_parentid = parentid
+    curr_stitched = parentid and parentid > 0 and exitnum == -1
+
+    debugprint("START(%d): parent = %d", tr, parentid or -1)
+    
+    stats.starts = stats.starts + 1
+    if curr_stitched then
+        stats.stitch_starts = stats.stitch_starts + 1
+    elseif parentid then
+        stats.side_starts = stats.side_starts + 1
+    end 
+end
+
+--Trace Stopped
+function vmevent.stop(tr)
+    local info = jutil.traceinfo(tr)
+     
+    debugprint("STOP(%d): link = %s", tr, info.linktype)
+    
+    stats.completed = stats.completed + 1
+    
+    if curr_stitched then
+        stats.stitch_completed = stats.stitch_completed + 1
+    elseif curr_parentid then
+        stats.side_completed = stats.side_completed + 1
+    end
+
+    stats.linktypes[info.linktype] = (stats.linktypes[info.linktype] or 0) + 1
+end
+
+--Trace Aborted
+function vmevent.abort(tr, func, pc, code, errinfo)
+    stats.aborts = stats.aborts + 1
+    
+    local reason = ""
+    if jitstats.debug then
+        reason = fmterr(code, errinfo)
+        reason = reason:gsub("bytecode (%d+)", function(c)
+            c = tonumber(c)
+            assert(bcnames[c], c)
+            return "bytecode "..bcnames[c]
+        end)
+    end
+
+    if curr_stitched then
+        stats.stitch_aborts = stats.stitch_aborts + 1
+    elseif curr_parentid then
+        debugprint("ABORT(%d): parent = %d, %s", tr, curr_parentid, reason)
+        stats.side_aborts = stats.side_aborts + 1
+    else
+        debugprint("ABORT(%d): %s", tr, reason)
+    end
+
+    -- We sometimes don't get a bc for the stop location
+    local bc = funcbc(func, pc)
+    local opcode = bc and band(bc, 0xff)
+    
+    if code == traceerr.LLEAVE then
+        debugprint("LLEAVE: %d/%s", opcode, bcnames[opcode])
+    elseif code == traceerr.LUNROLL then
+        
+    elseif code == traceerr.NYIBC then
+        bcname = bcnames[errinfo]
+        stats.nyi_bc[bcname] = (stats.nyi_bc[bcname] or 0) + 1
+    end
+
+    -- Use internal enum name of the trace abort error if possible
+    local tracerror = traceerr_fromid[code] or vmdef.traceerr[code]
+    stats.abort_counts[tracerror] = (stats.abort_counts[tracerror] or 0) + 1
+end
+
+function vmevent.flush()
+    debugprint("Full trace flush")
+    stats.traceflush = stats.traceflush + 1
+end
+
+function vmevent.texit(id, exitno)
+    debugprint("EXIT(%d): exit = %d", id, exitno)
+    stats.exits = stats.exits + 1
+end
+
+local function vmeventcb(what, ...)
+    local cb = vmevent[what]
+    if cb then 
+        cb(...)
+    end
+end
+
+function jitstats.start()
+    if jitstats.isrunning then
+        return false
+    end
+
+    jit.attach(vmeventcb, "trace")
+    jit.attach(vmevent.texit, "texit")
+    jitstats.isrunning = true
+    return true
+end
+
+function jitstats.stop()
+    if not jitstats.isrunning then
+        return false
+    end
+
+    jit.attach(vmeventcb)
+    jit.attach(vmevent.texit)
+    jitstats.isrunning = false
+    return true
+end
+
+local function initorclear(tab, key)
+    local t = tab[key]
+    if t then
+        table.clear(t)
+    else
+        tab[key] = {}
+    end
+end
+
+local function reset_subtables(statstbl)
+    initorclear(statstbl, "abort_counts")
+    initorclear(statstbl, "nyi_bc")
+    initorclear(statstbl, "linktypes")
+end
+
+function jitstats.reset(statstbl)
+    statstbl = statstbl or stats
+    statstbl.starts = 0
+    statstbl.aborts = 0
+    statstbl.completed = 0
+    statstbl.stitch_starts = 0
+    statstbl.stitch_aborts = 0
+    statstbl.stitch_completed = 0
+    statstbl.side_starts = 0
+    statstbl.side_aborts = 0  
+    statstbl.side_completed = 0
+    statstbl.exits = 0
+    statstbl.traceflush = 0
+    --Clear or initlize 
+    reset_subtables(statstbl)
+end
+
+-- Note no attempt is made to handle circular references
+local function table_copy(src, dst)
+    dst = dst or {}
+    for k,v in pairs(src) do
+        if type(v) == "table" then
+            dst[k] = table_copy(v, dst[k])
+        else
+            dst[k] = v
+        end
+    end
+    return dst
+end
+
+--Optionally pass in a table to write the snapshot to instead of creating a new table
+function jitstats.getsnapshot(dst)
+    if dst then
+        reset_subtables(dst)
+    end
+    return table_copy(stats, dst)
+end
+
+local function diffstatbl(old, new, result, key)
+    assert(old[key], "missing old sub table")
+    assert(new[key], "missing new sub table")
+    assert(result[key], "missing result sub table")
+    old = old[key]
+    new = new[key]
+    result = result[key]
+
+    for k, v in pairs(new) do
+        local change = v - (old[k] or 0)
+        if change ~= 0 then
+            result[k] = change
+        end
+    end
+    return result
+end
+
+-- Get the diff between two jit stat snapshots
+function jitstats.diffsnapshots(snap1, snap2)
+    local result = {
+        abort_counts = {},
+        nyi_bc = {},
+        linktypes = {},
+    }
+
+    for k, v in pairs(snap2) do   
+        if type(v) == "number" then
+            result[k] = v - (snap1[k] or 0)
+        end
+    end
+
+    diffstatbl(snap1, snap2, result, "abort_counts")
+    diffstatbl(snap1, snap2, result, "nyi_bc")
+    diffstatbl(snap1, snap2, result, "linktypes")
+
+    return result
+end
+
+-- Checks if the current stats have changed compared to the snapshot passed in
+function jitstats.stats_changed(snapshot) 
+    return snapshot.starts ~= stats.starts or snapshot.exits ~= stats.exits or 
+           snapshot.traceflush ~= stats.traceflush
+end
+
+function jitstats.setdebugprint(enable)
+    jitstats.debug = enable
+    debugprint = (enable and printf) or function() end
+end
+
+local function valpercent(total, subval)
+    return string.format("%d(%.0f%%)", subval, subval / total * 100)
+end
+
+function jitstats.print_simple(msg)
+    local running = jitstats.stop()
+    printf("%sStarted %d, Aborted %d, Exits %d", msg or "", stats.starts, stats.aborts, stats.exits)
+    if running then
+        jitstats.start()
+    end
+end
+
+local function table_keys(t)
+    local result = {}
+    for k,_ in pairs(t) do
+        table.insert(result, k)
+    end
+    return result
+end
+
+local function statstbl_sortkeys(t, sorter)
+    local keys = table_keys(t) 
+    table.sort(keys, function(k1, k2) return t[k1] > t[k2] end)
+    return keys
+end
+
+local function statstbl_concat(tbl)
+    local strings = {}
+    local count = 0
+    for k, v in pairs(tbl) do
+        count = count + 1
+        strings[count] = k.." = "..v
+    end
+    
+    return table.concat(strings, ", ")
+end
+
+local function buildtemplate(template, values)
+  return (string.gsub(template, "{{([^\n]-)}}", function(key)
+    if values[key] == nil then
+        error("missing value for template key '"..key.."'")
+    end
+    return values[key]
+  end))
+end
+
+function jitstats.print(statstbl, msg)
+    local running = jitstats.stop()
+
+    if not statstbl then
+        statstbl = stats
+        msg = "Trace Stats:"
+    elseif type(statstbl) == "string" then
+        assert(msg == nil)
+        msg = statstbl
+        statstbl = stats
+    else
+        assert(type(statstbl) == "table", type(statstbl))
+        msg = "Trace Stats:"
+    end
+
+    printf(msg)
+
+    if statstbl.traceflush > 0 then
+        printf("  Full trace flush(all traces) %d", statstbl.traceflush)
+    end
+   
+    local values = {
+        side_starts = valpercent(statstbl.starts, statstbl.side_starts),
+        stitch_starts = valpercent(statstbl.starts, statstbl.stitch_starts),
+        aborts = valpercent(statstbl.starts, statstbl.aborts),
+        side_aborts = valpercent(statstbl.starts, statstbl.side_aborts),
+        stitch_aborts = valpercent(statstbl.starts, statstbl.stitch_aborts),
+        linktypes = statstbl_concat(statstbl.linktypes),
+    }
+    setmetatable(values, {__index = statstbl})
+
+    print(buildtemplate([[
+  Started {{starts}}, side {{side_starts}}, stitch {{stitch_starts}}
+  Completed Link types: {{linktypes}}
+  Aborted {{aborts}}, side {{side_aborts}}, stitch {{stitch_aborts}}]], values))
+
+    local sortedkeys = statstbl_sortkeys(statstbl.abort_counts)
+
+    for _, name in ipairs(sortedkeys) do
+        local msg = traceerr_displaymsg[name] or name
+        printf("    %d %s", statstbl.abort_counts[name], msg)
+    end
+
+    -- Print NYI bytecode abort counts
+    if next(statstbl.nyi_bc) then
+        printf("  NYI BC Aborts")
+        sortedkeys = statstbl_sortkeys(statstbl.nyi_bc)
+        for _, bc in ipairs(sortedkeys) do
+            printf("    %d %s", statstbl.nyi_bc[bc], bc)
+        end
+    end
+    
+    printf(" Uncompiled exits taken %d", statstbl.exits)
+    
+    if running then
+        jitstats.start()
+    end
+end
+
+jitstats.reset()
+return jitstats

--- a/jitstats.lua
+++ b/jitstats.lua
@@ -444,5 +444,11 @@ function jitstats.print(statstbl, msg)
     end
 end
 
+-- Turn off the JIT for all the functions in this file so they don't inflate the JIT stats when called.
+-- Unfortunately these functions still decrement the hot counters until they reach zero. Instead of tracing,
+-- the triggering bytecode is patched to interpreter only. This means no VM events are triggered for these points
+-- for us to worry about.
+jit.off(true, true)
+
 jitstats.reset()
 return jitstats

--- a/lualibs/json_nojit.lua
+++ b/lualibs/json_nojit.lua
@@ -1,0 +1,385 @@
+--
+-- json.lua
+--
+-- Copyright (c) 2015 rxi
+--
+-- This library is free software; you can redistribute it and/or modify it
+-- under the terms of the MIT license. See LICENSE for details.
+--
+
+local json = { _version = "0.1.0" }
+
+-------------------------------------------------------------------------------
+-- Encode
+-------------------------------------------------------------------------------
+
+local encode
+
+local escape_char_map = {
+  [ "\\" ] = "\\\\",
+  [ "\"" ] = "\\\"",
+  [ "\b" ] = "\\b",
+  [ "\f" ] = "\\f",
+  [ "\n" ] = "\\n",
+  [ "\r" ] = "\\r",
+  [ "\t" ] = "\\t",
+}
+
+local escape_char_map_inv = { [ "\\/" ] = "/" }
+for k, v in pairs(escape_char_map) do
+  escape_char_map_inv[v] = k
+end
+
+
+local function escape_char(c)
+  return escape_char_map[c] or string.format("\\u%04x", c:byte())
+end
+
+
+local function encode_nil(val)
+  return "null"
+end 
+
+
+local function encode_table(val, stack)
+  local res = {}
+  stack = stack or {}
+
+  -- Circular reference?
+  if stack[val] then error("circular reference") end
+
+  stack[val] = true
+
+  if val[1] ~= nil or next(val) == nil then
+    -- Treat as array -- check keys are valid and it is not sparse
+    local n = 0
+    for k in pairs(val) do
+      if type(k) ~= "number" then
+        error("invalid table: mixed or invalid key types")
+      end
+      n = n + 1
+    end
+    if n ~= #val then
+      error("invalid table: sparse array")
+    end
+    -- Encode
+    for i, v in ipairs(val) do
+      table.insert(res, encode(v, stack))
+    end
+    stack[val] = nil
+    return "[" .. table.concat(res, ",") .. "]"
+
+  else
+    -- Treat as an object
+    for k, v in pairs(val) do
+      if type(k) ~= "string" then
+        error("invalid table: mixed or invalid key types")
+      end
+      table.insert(res, encode(k, stack) .. ":" .. encode(v, stack))
+    end
+    stack[val] = nil
+    return "{" .. table.concat(res, ",") .. "}"
+  end
+end
+
+
+local function encode_string(val)
+  return '"' .. val:gsub('[%z\1-\31\\"]', escape_char) .. '"'
+end
+
+
+local function encode_number(val)
+  -- Check for NaN, -inf and inf
+  if val ~= val or val <= -math.huge or val >= math.huge then
+    error("unexpected number value '" .. tostring(val) .. "'")
+  end
+  return string.format("%.14g", val)
+end
+
+
+local type_func_map = {
+  [ "nil"     ] = encode_nil,
+  [ "table"   ] = encode_table,
+  [ "string"  ] = encode_string,
+  [ "number"  ] = encode_number,
+  [ "boolean" ] = tostring,
+}
+
+
+encode = function(val, stack)
+  local t = type(val)
+  local f = type_func_map[t]
+  if f then
+    return f(val, stack)
+  end
+  error("unexpected type '" .. t .. "'")
+end
+
+
+function json.encode(val)
+  return ( encode(val) )
+end
+
+
+-------------------------------------------------------------------------------
+-- Decode
+-------------------------------------------------------------------------------
+
+local parse
+
+local function create_set(...) 
+  local res = {}
+  for i = 1, select("#", ...) do
+    res[ select(i, ...) ] = true
+  end
+  return res
+end
+
+local space_chars   = create_set(" ", "\t", "\r", "\n")
+local delim_chars   = create_set(" ", "\t", "\r", "\n", "]", "}", ",")
+local escape_chars  = create_set("\\", "/", '"', "b", "f", "n", "r", "t", "u")
+local literals      = create_set("true", "false", "null")
+
+local literal_map = {
+  [ "true"  ] = true,
+  [ "false" ] = false,
+  [ "null"  ] = nil,
+}
+
+
+local function next_char(str, idx, set, negate)
+  for i = idx, #str do
+    if set[str:sub(i, i)] ~= negate then
+      return i
+    end
+  end
+  return #str + 1
+end
+
+
+local function decode_error(str, idx, msg)
+  local line_count = 1
+  local col_count = 1
+  for i = 1, idx - 1 do
+    col_count = col_count + 1
+    if str:sub(i, i) == "\n" then
+      line_count = line_count + 1
+      col_count = 1
+    end
+  end
+  error( string.format("%s at line %d col %d", msg, line_count, col_count) )
+end
+
+
+local function codepoint_to_utf8(n)
+  -- http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=iws-appendixa
+  local f = math.floor
+  if n <= 0x7f then
+    return string.char(n)
+  elseif n <= 0x7ff then
+    return string.char(f(n / 64) + 192, n % 64 + 128)
+  elseif n <= 0xffff then
+    return string.char(f(n / 4096) + 224, f(n % 4096 / 64) + 128, n % 64 + 128)
+  elseif n <= 0x10ffff then
+    return string.char(f(n / 262144) + 240, f(n % 262144 / 4096) + 128,
+                       f(n % 4096 / 64) + 128, n % 64 + 128)
+  end
+  error( string.format("invalid unicode codepoint '%x'", n) )
+end
+
+
+local function parse_unicode_escape(s)
+  local n1 = tonumber( s:sub(3, 6),  16 )
+  local n2 = tonumber( s:sub(9, 12), 16 )
+  -- Surrogate pair?
+  if n2 then
+    return codepoint_to_utf8((n1 - 0xd800) * 0x400 + (n2 - 0xdc00) + 0x10000)
+  else
+    return codepoint_to_utf8(n1)
+  end
+end
+
+
+local function parse_string(str, i)
+  local has_unicode_escape = false
+  local has_surrogate_escape = false
+  local has_escape = false
+  local last
+  for j = i + 1, #str do
+    local x = str:byte(j)
+
+    if x < 32 then
+      decode_error(str, j, "control character in string")
+    end
+
+    if last == 92 then -- "\\" (escape char)
+      if x == 117 then -- "u" (unicode escape sequence)
+        local hex = str:sub(j + 1, j + 5)
+        if not hex:find("%x%x%x%x") then
+          decode_error(str, j, "invalid unicode escape in string")
+        end
+        if hex:find("^[dD][89aAbB]") then
+          has_surrogate_escape = true
+        else
+          has_unicode_escape = true
+        end
+      else
+        local c = string.char(x)
+        if not escape_chars[c] then
+          decode_error(str, j, "invalid escape char '" .. c .. "' in string")
+        end
+        has_escape = true
+      end
+      last = nil
+
+    elseif x == 34 then -- '"' (end of string)
+      local s = str:sub(i + 1, j - 1)
+      if has_surrogate_escape then 
+        s = s:gsub("\\u[dD][89aAbB]..\\u....", parse_unicode_escape)
+      end
+      if has_unicode_escape then 
+        s = s:gsub("\\u....", parse_unicode_escape)
+      end
+      if has_escape then
+        s = s:gsub("\\.", escape_char_map_inv)
+      end
+      return s, j + 1
+    
+    else
+      last = x
+    end
+  end
+  decode_error(str, i, "expected closing quote for string")
+end
+
+
+local function parse_number(str, i)
+  local x = next_char(str, i, delim_chars)
+  local s = str:sub(i, x - 1)
+  local n = tonumber(s)
+  if not n then
+    decode_error(str, i, "invalid number '" .. s .. "'")
+  end
+  return n, x
+end
+
+
+local function parse_literal(str, i)
+  local x = next_char(str, i, delim_chars)
+  local word = str:sub(i, x - 1)
+  if not literals[word] then
+    decode_error(str, i, "invalid literal '" .. word .. "'")
+  end
+  return literal_map[word], x
+end
+
+
+local function parse_array(str, i)
+  local res = {}
+  local n = 1
+  i = i + 1
+  while 1 do
+    local x
+    i = next_char(str, i, space_chars, true)
+    -- Empty / end of array?
+    if str:sub(i, i) == "]" then 
+      i = i + 1
+      break
+    end
+    -- Read token
+    x, i = parse(str, i)
+    res[n] = x
+    n = n + 1
+    -- Next token 
+    i = next_char(str, i, space_chars, true)
+    local chr = str:sub(i, i)
+    i = i + 1
+    if chr == "]" then break end
+    if chr ~= "," then decode_error(str, i, "expected ']' or ','") end
+  end
+  return res, i
+end
+
+
+local function parse_object(str, i)
+  local res = {}
+  i = i + 1
+  while 1 do
+    local key, val
+    i = next_char(str, i, space_chars, true)
+    -- Empty / end of object?
+    if str:sub(i, i) == "}" then 
+      i = i + 1
+      break
+    end
+    -- Read key
+    if str:sub(i, i) ~= '"' then
+      decode_error(str, i, "expected string for key")
+    end
+    key, i = parse(str, i)
+    -- Read ':' delimiter
+    i = next_char(str, i, space_chars, true)
+    if str:sub(i, i) ~= ":" then
+      decode_error(str, i, "expected ':' after key")
+    end
+    i = next_char(str, i + 1, space_chars, true)
+    -- Read value
+    val, i = parse(str, i)
+    -- Set
+    res[key] = val
+    -- Next token
+    i = next_char(str, i, space_chars, true)
+    local chr = str:sub(i, i)
+    i = i + 1
+    if chr == "}" then break end
+    if chr ~= "," then decode_error(str, i, "expected '}' or ','") end
+  end
+  return res, i
+end
+
+
+local char_func_map = {
+  [ '"' ] = parse_string,
+  [ "0" ] = parse_number,
+  [ "1" ] = parse_number,
+  [ "2" ] = parse_number,
+  [ "3" ] = parse_number,
+  [ "4" ] = parse_number,
+  [ "5" ] = parse_number,
+  [ "6" ] = parse_number,
+  [ "7" ] = parse_number,
+  [ "8" ] = parse_number,
+  [ "9" ] = parse_number,
+  [ "-" ] = parse_number,
+  [ "t" ] = parse_literal,
+  [ "f" ] = parse_literal,
+  [ "n" ] = parse_literal,
+  [ "[" ] = parse_array,
+  [ "{" ] = parse_object,
+}
+
+
+parse = function(str, idx)
+  local chr = str:sub(idx, idx)
+  local f = char_func_map[chr]
+  if f then
+    return f(str, idx)
+  end
+  decode_error(str, idx, "unexpected character '" .. chr .. "'")
+end
+
+
+function json.decode(str)
+  if type(str) ~= "string" then
+    error("expected argument of type string, got " .. type(str))
+  end
+  return ( parse(str, next_char(str, 1, space_chars, true)) )
+end
+
+local jit = pcall(require, "jit")
+
+if jit then
+   require("jit").off(true, true) 
+end
+
+return json

--- a/simplerunner.lua
+++ b/simplerunner.lua
@@ -1,4 +1,17 @@
 package.path = package.path ..";lualibs/?/init.lua;lualibs/?.lua;lualibs/?/?.lua"
+local json = require("json_nojit")
+require("table.new")
+
+if not pcall(require, "jit.vmdef") then
+    package.path = package.path ..";luajit_repo/src/?/init.lua;luajit_repo/src/?.lua;luajit_repo/src/?/?.lua"
+end
+
+local success, jitstats = pcall(require, "jitstats")
+
+if not success then
+    print("Warning: Failed to load jitstats")
+    jitstats = nil
+end
 
 local benchlist = {
     "binarytrees",
@@ -18,16 +31,54 @@ local benchlist = {
     "luafun",
 }
 
+function runbench_jitstats(name, count)
+    if count == 1 then
+        local start = os.clock()
+        run_iter(count)
+        print(name.." took", os.clock() - start)
+        jitstats.print()
+        jitstats.reset()
+    else
+        local stats = table.new(count, 0)
+        local start, stop = {}, {}
+
+        for i = 1, count do
+            jitstats.getsnapshot(start)
+            run_iter(1)
+            jitstats.getsnapshot(stop)
+            stats[i] = jitstats.diffsnapshots(start, stop)
+        end
+
+        jitstats.print()
+        --print(json.encode(jitstats.getsnapshot()))
+    end
+end
+
 function runbench(name, count)
+    if jitstats then
+        jitstats.start()
+    end
     dofile("benchmarks/"..name.."/bench.lua")
 
     if not run_iter then
         error("Missing benchmark function for '"..name.."'")
     end
 
-    local start = os.clock()
-    run_iter(count or 1)
-    print(name.." took", os.clock() - start)  
+    count = count or 1
+    
+    if jitstats then 
+        if jitstats.stats.starts > 0 then
+            print("Traces created while loading benchmark")
+            jitstats.print()
+            jitstats.reset()
+        end
+        
+        runbench_jitstats(name, count)
+    else
+        local start = os.clock()
+        run_iter(count)
+        print(name.." took", os.clock() - start)
+    end
 
     --Clear the benchmark function so we know we're not running this benchmark again when we load another benchmark.
     run_iter = nil


### PR DESCRIPTION
Add jitstats a pure Lua low overhead JIT stats tracking library that use the vmevent hooks to track trace behaviour and builds the stats based on trace start\stop\aborts .



