### PR TITLE
Copy the build artifacts for each VM flavor to a sub directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ luajit.manifest
 luajit_*.log
 luajit_results.json.bz2
 luajit_instr_data/
+/builds/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_script:
   - ./build_luajit.sh
 
 script:
-  - ./builds/luajit_nojit simplerunner.lua
-  - ./builds/luajit simplerunner.lua
-  - ./builds/luajit_gc64 simplerunner.lua
-  - ./builds/luajit_dualnum simplerunner.lua
-  - ./builds/raptorjit simplerunner.lua
+  - ./builds/nojit/luajit simplerunner.lua
+  - ./builds/normal/luajit simplerunner.lua
+  - ./builds/gc64/luajit simplerunner.lua
+  - ./builds/dualnum/luajit simplerunner.lua
+  - ./builds/raptorjit/luajit simplerunner.lua

--- a/build_luajit.sh
+++ b/build_luajit.sh
@@ -36,30 +36,40 @@ mkdir -p ${ljbins}
 # Make directory path relative so we don't have to worry about what path we have to pass to make.
 ljbins="$( cd "$ljbins" && pwd )"
 
+function copy_binaries() {
+    mkdir -p ${ljbins}/$1/jit/
+    cp ${ljsrc}/luajit ${ljbins}/$1/luajit
+    cp ${ljsrc}/libluajit.so ${ljbins}/$1/libluajit.so
+    cp ${ljsrc}/jit/*.lua ${ljbins}/$1/jit/
+}
+  
 #Unmodified build with 32 bit sized gc object pointers. Object allocataion limited to the lower 4gb virtual address space
 make -C ${ljsrc} clean
 make -C ${ljsrc} -j
-cp ${ljsrc}/luajit ${ljbins}/luajit
+copy_binaries "normal"
 
 #Build with JIT removed
 make -C ${ljsrc} clean
 make -C ${ljsrc} -j XCFLAGS=-DLUAJIT_DISABLE_JIT
-cp ${ljsrc}/luajit ${ljbins}/luajit_nojit
+copy_binaries "nojit"
 
-#GC64 64 bit sized gc object pointer
+##GC64 64 bit sized gc object pointer
 make -C ${ljsrc} clean
 make -C ${ljsrc} -j XCFLAGS=-DLUAJIT_ENABLE_GC64
-cp ${ljsrc}/luajit ${ljbins}/luajit_gc64
+copy_binaries "gc64"
 
-# Build with dual number mode enabled
+## Build with dual number mode enabled
 make -C ${ljsrc} clean
 make -C ${ljsrc} -j XCFLAGS=-DLUAJIT_NUMMODE=2
-cp ${ljsrc}/luajit ${ljbins}/luajit_dualnum
+copy_binaries "dualnum"
 
 if [ -d "raptorjit_repo" ]; then
-  make -C ./raptorjit_repo clean
-  make -C ./raptorjit_repo -j HOST_LUA=${ljbins}/luajit
-  cp ./raptorjit_repo/src/raptorjit ${ljbins}/raptorjit
+    make -C ./raptorjit_repo clean
+    make -C ./raptorjit_repo -j HOST_LUA=${ljbins}/normal/luajit
+    mkdir -p ${ljbins}/raptorjit/jit/
+    cp ./raptorjit_repo/src/raptorjit ${ljbins}/raptorjit/luajit
+    cp ./raptorjit_repo/src/libraptorjit.so ${ljbins}/raptorjit/libluajit.so
+    cp ./raptorjit_repo/src/jit/*.lua ${ljbins}/raptorjit/jit/
 fi
 
 #32 bit build

--- a/luajit.krun
+++ b/luajit.krun
@@ -12,10 +12,13 @@ MAIL_TO = []
 
 DIR = os.getcwd()
 
-VM_ENV = {
-  'LUA_PATH' : '"{0}/?/init.lua;{0}/?.lua;{0}/?/?.lua;"'.format(os.path.join(DIR, "lualibs")) + 
-               '"{0}/?/init.lua;{0}/?.lua;{0}/?/?.lua;"'.format(os.path.join(DIR, "luajit_repo/src"))
-}
+VM_ENV = '"{0}/?/init.lua;{0}/?.lua;{0}/?/?.lua;"'.format(os.path.join(DIR, "lualibs"))
+
+def make_env(vmdir):
+  basedir = os.path.join(DIR, "builds", vmdir)
+  return {
+    'LUA_PATH' : VM_ENV + '"{0}/?/init.lua;{0}/?.lua;{0}/?/?.lua;"'.format(basedir) 
+  }
 
 HEAP_LIMIT = 2097152  # KiB
 STACK_LIMIT = 8192  # KiB
@@ -67,27 +70,27 @@ class LuaJITVMDef(GenericScriptingVMDef):
 
 VMS = {
     'Normal': {
-        'vm_def': LuaJITVMDef("builds/luajit", env=VM_ENV,instrument=INSTRUMENT),
+        'vm_def': LuaJITVMDef("builds/normal/luajit", env=make_env("normal"), instrument=INSTRUMENT),
         'variants': ['default-lua'],
         'n_iterations': ITERATIONS_ALL_VMS,
     },
     'GC64': {
-        'vm_def': LuaJITVMDef("builds/luajit_gc64", env=VM_ENV,instrument=INSTRUMENT),
+        'vm_def': LuaJITVMDef("builds/gc64/luajit", env=make_env("gc64"), instrument=INSTRUMENT),
         'variants': ['default-lua'],
         'n_iterations': ITERATIONS_ALL_VMS,
     },
     'NoJIT': {
-        'vm_def': LuaJITVMDef("builds/luajit_nojit", env=VM_ENV),
+        'vm_def': LuaJITVMDef("builds/nojit/luajit", env=make_env("nojit")),
         'variants': ['default-lua'],
         'n_iterations': ITERATIONS_NO_JIT,
     },
     'DualNum': {
-        'vm_def': LuaJITVMDef("builds/luajit_dualnum", env=VM_ENV,instrument=INSTRUMENT),
+        'vm_def': LuaJITVMDef("builds/dualnum/luajit", env=make_env("dualnum"), instrument=INSTRUMENT),
         'variants': ['default-lua'],
         'n_iterations': ITERATIONS_ALL_VMS,
     },
     'RaptorJIT': {
-        'vm_def': LuaJITVMDef("builds/raptorjit", env=VM_ENV),
+        'vm_def': LuaJITVMDef("builds/raptorjit/luajit", env=make_env("raptorjit")),
         'variants': ['default-lua'],
         'n_iterations': ITERATIONS_ALL_VMS,
     },


### PR DESCRIPTION
Instead of giving each vm builds executable a different name just copy to a sub folder along the with the builtin jit lua modules that will vary(mostly vmdef.lua) between build flavours this will be needed to fix the "require" error in krun.