### PR TITLE
Add few helper shell scripts 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@ Thumbs.db
 
 # Visual Studio 2015 cache/options directory
 .vs/
-luajit_envlogs/
-luajit.manifest
-luajit_*.log
-luajit_results.json.bz2
-luajit_instr_data/
 /builds/
+*.manifest
+luajit_*.log
+quicktest_*.log
+*_envlogs/
+*_results.json.bz2
+*_instr_data/
+bencher_*.log

--- a/bencher.krun
+++ b/bencher.krun
@@ -1,0 +1,43 @@
+execfile("luajit.krun", globals()) # inherit settings from the main experiment
+
+MAIL_TO = ["fsfod11@gmail.com"]
+
+PRE_EXECUTION_CMDS = [
+    "sudo systemctl stop apt-daily.timer",
+    "sudo systemctl --runtime disable apt-daily.timer",
+
+    "sudo systemctl stop apt-daily-upgrade.timer",
+    "sudo systemctl --runtime disable apt-daily-upgrade.timer",
+
+    "sudo systemctl stop systemd-tmpfiles-clean.timer",
+    "sudo systemctl --runtime disable systemd-tmpfiles-clean.timer",
+
+    "sudo systemctl stop systemd-timesyncd",
+    "sudo systemctl --runtime disable systemd-timesyncd",
+
+    "sudo systemctl stop cron",
+]
+
+POST_EXECUTION_CMDS = [
+    "sudo systemctl start systemd-timesyncd || true",
+    "sudo systemctl start cron || true",
+
+    "sudo systemctl --runtime enable apt-daily.timer || true",
+    "sudo systemctl start apt-daily.timer || true",
+
+    "sudo systemctl --runtime enable apt-daily-upgrade.timer || true",
+    "sudo systemctl start apt-daily-upgrade.timer || true",
+
+    "sudo systemctl --runtime enable systemd-tmpfiles-clean.timer || true",
+    "sudo systemctl start systemd-tmpfiles-clean.timer || true",
+]
+
+def custom_dmesg_whitelist(defaults):
+    return defaults + [
+      "^.*en[0-9a-zA-Z]+: link (down|up)",
+      "^.*en[0-9a-zA-Z]+: Link is (up|down).*",
+      "^.*en[0-9a-zA-Z]+: Flow control is (on|off).*",
+      "^.*en[0-9a-zA-Z]+: EEE is (enabled|disabled).*",
+      "^.*random: crng init done",
+      "^.*apt-daily-upgrade.timer: Adding.*",
+    ]

--- a/quicktest.krun
+++ b/quicktest.krun
@@ -1,0 +1,8 @@
+# Krun config file aimed to help quickly test all the benchmarks work under krun
+
+execfile("luajit.krun", globals()) # inherit settings from the main experiment
+
+for key, vm in VMS.iteritems():
+  vm["n_iterations"] = 2
+
+N_EXECUTIONS = 1

--- a/quicktest.sh
+++ b/quicktest.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+../krun/krun.py --no-pstate-check --no-tickless-check --quick --debug info --quick quicktest.krun

--- a/resetkrun.sh
+++ b/resetkrun.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+function clean_results() {
+  (shopt -s nullglob; rm -rf $1*{log,manifest,bz2,envlogs,env,instr_data})
+}
+
+clean_results "luajit"
+clean_results "quicktest"
+clean_results "bencher"


### PR DESCRIPTION
resetkrun.sh clears out all the files generated from krun and quicktest.sh runs the bechmarks with a overlay krun file quicktest.krun that only runs one iteration for each benchmark