### PR TITLE
Revamp simplerunner.lua to make running/creating benchmarks easier 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_script:
   - ./build.sh
 
 script:
-  - ./builds/nojit/luajit simplerunner.lua
-  - ./builds/normal/luajit simplerunner.lua
-  - ./builds/gc64/luajit simplerunner.lua
-  - ./builds/dualnum/luajit simplerunner.lua
-  - ./builds/raptorjit/luajit simplerunner.lua
+  - ./builds/nojit/luajit simplerunner.lua 1
+  - ./builds/normal/luajit simplerunner.lua --jitstats 3
+  - ./builds/gc64/luajit simplerunner.lua 3
+  - ./builds/dualnum/luajit simplerunner.lua 3
+  - ./builds/raptorjit/luajit simplerunner.lua 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ before_script:
 script:
   - ./builds/nojit/luajit simplerunner.lua 1
   - ./builds/normal/luajit simplerunner.lua --jitstats 3
-  - ./builds/gc64/luajit simplerunner.lua 3
+  - ./builds/gc64/luajit simplerunner.lua -e capnproto_decode 3
   - ./builds/dualnum/luajit simplerunner.lua 3
-  - ./builds/raptorjit/luajit simplerunner.lua 3
+  - ./builds/raptorjit/luajit simplerunner.lua -e capnproto_decode 3

--- a/benchinfo.json
+++ b/benchinfo.json
@@ -1,0 +1,19 @@
+{
+  "scaling" : {
+    "binarytrees" : 2,
+    "nbody" : 10,
+    "fasta": 40,
+    "richards": 30,
+    "spectralnorm": 2,
+    "fannkuch_redux": 45,
+    "md5": 140,
+    "series": 2,
+    "luacheck_parser": 1,
+    "luacheck": 1,
+    "capnproto_encode": 240,
+    "capnproto_decode": 400,
+    "jsonlua_encode": 10,
+    "jsonlua_decode": 200,
+    "luafun": 4,
+  }
+}

--- a/lualibs/jitstats.lua
+++ b/lualibs/jitstats.lua
@@ -432,12 +432,13 @@ function jitstats.print(statstbl, msg)
         side_aborts = valpercent(statstbl.starts, statstbl.side_aborts),
         stitch_aborts = valpercent(statstbl.starts, statstbl.stitch_aborts),
         linktypes = statstbl_concat(statstbl.linktypes),
+        completed = valpercent(statstbl.starts, statstbl.completed),
     }
     setmetatable(values, {__index = statstbl})
 
     print(buildtemplate([[
   Started {{starts}}, side {{side_starts}}, stitch {{stitch_starts}}
-  Completed Link types: {{linktypes}}
+  Completed {{completed}} Link types: {{linktypes}}
   Aborted {{aborts}}, side {{side_aborts}}, stitch {{stitch_aborts}}]], values))
 
     local sortedkeys = statstbl_sortkeys(statstbl.abort_counts)

--- a/lualibs/time.lua
+++ b/lualibs/time.lua
@@ -1,0 +1,152 @@
+
+--wall-clock time, monotonic time and sleeping for Windows, Linux and OSX.
+--Written by Cosmin Apreutesei. Public Domain.
+
+local ffi = require'ffi'
+
+local M = {}
+local C = ffi.C
+
+if ffi.os == 'Windows' then
+
+	ffi.cdef[[
+	void time_GetSystemTimeAsFileTime(uint64_t*) asm("GetSystemTimeAsFileTime");
+	int  time_QueryPerformanceCounter(int64_t*) asm("QueryPerformanceCounter");
+	int  time_QueryPerformanceFrequency(int64_t*) asm("QueryPerformanceFrequency");
+	void time_Sleep(uint32_t ms) asm("Sleep");
+	]]
+
+	local t = ffi.new'uint64_t[1]'
+	local DELTA_EPOCH_IN_100NS = 116444736000000000ULL
+
+	function M.time()
+		C.time_GetSystemTimeAsFileTime(t)
+		return tonumber(t[0] - DELTA_EPOCH_IN_100NS) / 10^7
+	end
+
+	assert(C.time_QueryPerformanceFrequency(t) ~= 0)
+	local qpf = tonumber(t[0])
+
+	function M.clock()
+		assert(C.time_QueryPerformanceCounter(t) ~= 0)
+		return tonumber(t[0]) / qpf
+	end
+
+	function M.sleep(s)
+		C.time_Sleep(s * 1000)
+	end
+
+elseif ffi.os == 'Linux' or ffi.os == 'OSX' then
+
+	ffi.cdef[[
+	typedef struct {
+		long s;
+		long ns;
+	} time_timespec;
+
+	int time_nanosleep(time_timespec*, time_timespec *) asm("nanosleep");
+	]]
+
+	local EINTR = 4
+
+	local t = ffi.new'time_timespec'
+
+	function M.sleep(s)
+		local int, frac = math.modf(s)
+		t.s = int
+		t.ns = frac * 10^9
+		local ret = C.time_nanosleep(t, t)
+		while ret == -1 and ffi.errno() == EINTR do --interrupted
+			ret = C.time_nanosleep(t, t)
+		end
+		assert(ret == 0)
+	end
+
+	if ffi.os == 'Linux' then
+
+		ffi.cdef[[
+		int time_clock_gettime(int clock_id, time_timespec *tp) asm("clock_gettime");
+		]]
+
+		local CLOCK_REALTIME = 0
+		local CLOCK_MONOTONIC = 1
+
+		local clock_gettime = ffi.load'rt'.time_clock_gettime
+
+		local function tos(t)
+			return tonumber(t.s) + tonumber(t.ns) / 10^9
+		end
+
+		function M.time()
+			assert(clock_gettime(CLOCK_REALTIME, t) == 0)
+			return (tos(t))
+		end
+
+		function M.clock()
+			assert(clock_gettime(CLOCK_MONOTONIC, t) == 0)
+			return (tos(t))
+		end
+
+	elseif ffi.os == 'OSX' then
+
+		ffi.cdef[[
+		typedef struct {
+			long    s;
+			int32_t us;
+		} time_timeval;
+
+		typedef struct {
+			uint32_t numer;
+			uint32_t denom;
+		} time_mach_timebase_info_data_t;
+
+		int      time_gettimeofday(time_timeval*, void*) asm("gettimeofday");
+		int      time_mach_timebase_info(time_mach_timebase_info_data_t* info) asm("mach_timebase_info");
+		uint64_t time_mach_absolute_time(void) asm("mach_absolute_time");
+		]]
+
+		local t = ffi.new'time_timeval'
+
+		function M.time()
+			assert(C.time_gettimeofday(t, nil) == 0)
+			return tonumber(t.s) + tonumber(t.us) / 10^6
+		end
+
+		--NOTE: this appears to be pointless on Intel Macs. The timebase fraction
+		--is always 1/1 and mach_absolute_time() does dynamic scaling internally.
+		local timebase = ffi.new'time_mach_timebase_info_data_t'
+		assert(C.time_mach_timebase_info(timebase) == 0)
+		local scale = tonumber(timebase.numer) / tonumber(timebase.denom) / 10^9
+		function M.clock()
+			return tonumber(C.time_mach_absolute_time()) * scale
+		end
+
+	end --OSX
+
+end --Linux or OSX
+
+if not ... then
+	io.stdout:setvbuf'no'
+	local time = M
+
+	print('time ', time.time())
+	print('clock', time.clock())
+
+	local function test_sleep(s, ss)
+		local t0 = time.clock()
+		local times = math.floor(s*1/ss)
+		s = times * ss
+		print(string.format('sleeping %gms in %gms increments (%d times)...', s * 1000, ss * 1000, times))
+		for i=1,times do
+			time.sleep(ss)
+		end
+		local t1 = time.clock()
+		print(string.format('  missed by: %0.2fms', (t1 - t0 - s) * 1000))
+	end
+
+	test_sleep(0.001, 0.001)
+	test_sleep(0.2, 0.02)
+	test_sleep(2, 0.2)
+end
+
+return M


### PR DESCRIPTION
This is revamp of simplerunner.lua to help achieve the goal of #23 for providing a way to quickly run benchmarks and help in the process of making them.
There is now a basic command line option system borrowed from dynasm.lua. Some basic stats are now calculated and printed from all the iteration times. 
Passing no command line augments to simplerunner will cause it to run all the benchmarks each for 30 iterations and a default scaling of one. To run a single benchmark just pass benchmark name as the last command line entry. An optional iteration count can be specified after it like so

`simplerunner.lua luafun 1500`

Added basic progress indicator by printing a dot to the console for each iteration run.
Made collecting and printing jitstats off by default now..
Turned off JITing benchmark loop to try to keep the timing more stable.
Added optional support for using a more high res timer by using the ffi system otherwise os.clock is used. Also the functions used to get the highres time are also pre JIT'ed to try keep the timing stable.