### PR TITLE
Add printing the number of traces started in an iteration when using jitstats

### DIFF
--- a/simplerunner.lua
+++ b/simplerunner.lua
@@ -183,7 +183,11 @@ function runbench(name, count, scaling)
         table.insert(times, ticks)
         if jitstats then
             jitstats.getsnapshot(stop)
-            jstats[i] = jitstats.diffsnapshots(start, stop)
+            local iter_jstats = jitstats.diffsnapshots(start, stop)
+            jstats[i] = iter_jstats
+            if iter_jstats.starts ~= 0 then
+                io.write(iter_jstats.starts)
+            end
         end
     end
     -- Force a new line after our line of dots


### PR DESCRIPTION
I came up with a neat simple visualization of trace activity by printing the number of traces started after each progress dot if atleast one trace was attempted that iteration. This is only shown if you enable jitstats on the command line as well.

This is an example for luafun
```
Running luafun: .54.60.37.6.6.4.5.4.4.5.11.15.11.13.9.7...2.2.1.1..1.1.......1................
.............1......1..1........1..1.....................1.....1.................1.............1..........1.......1................1...............
............1.........................................1........................................................1.......1.........1..........1................
...........1........................................................................................................................................................
............................................................1......................................................2.......................1...............1........
.........................................................................................1.....................................................................
.........................................................................................................................................................................................
  Mean: 0.050910 +/- 0.000104, min 0.049400, max 0.078770
```

a more intresting one is luacheck

```
Running luacheck: .26711.27255.26790.27350.26805.26730.27079.27367.26227.26509.27527.26564.27144.26604.
27103.27271.27011.27272.27419.26791.27687.27684.27638.26840.27575.27088.26323.26431.
26891.27348
  Mean: 1.219837 +/- 0.031687, min 1.098975, max 1.185578
```

and after with max trace/mcode increased.

```
Running luacheck: .4832.1034.713.596.382.366.261.204.129.398.275.185.154.115.81.80.64.56.54.26.29.22.25.29.26.
15.17.14.8.23.31.17.16.10.7.11.9.12.8.5.7.5.4.9.4.4.1.4.16.8.4.6.9.7.21.10.9.8.5.14.7.4.7.4.7.5.5.3.4.6.
1.3..6.6.3.6.7.3.2.6..8.3.4.9.4.3.7.4.2.6.6.1.3.4.4.3.1.1
  Mean: 0.364255 +/- 0.002083, min 0.344213, max 0.399517
```