### PR TITLE
Simplerunner instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@ This repository collects together a number of open-source Lua benchmarks,
 suitable for quick or rigorous benchmarking. Contributions are welcome!
 
 
+## Quick benchmarking
+
+You can quickly run benchmarks by using your normal Lua interpreter to run
+`simplerunner.lua`. When called without arguments, this will run all benchmarks
+(taking some minutes) and print out means and confidence intervals which can be
+used for approximate comparisons. An example run looks as follows:
+
+```
+$ lua simplerunner.lua
+Running luacheck: ..............................
+  Mean: 1.120762 +/- 0.030216, min 1.004843, max 1.088270
+Running fannkuch_redux: ..............................
+  Mean: 0.128499 +/- 0.003281, min 0.119500, max 0.119847
+```
+
+You can run subsets of benchmarks or run benchmarks for longer (to achieve
+better quality statistics) -- see `simplerunner.lua -h` for more information.
+
+
 ## Adding new benchmarks
 
 New benchmarks should be put in the `benchmarks/` repository with an appropriate

--- a/simplerunner.lua
+++ b/simplerunner.lua
@@ -309,7 +309,7 @@ local opt_alias = {
 function opt_map.help()
     io.stdout:write[[
 
-Usage: simplerunner [OPTION]...  benchmark, count
+Usage: simplerunner [OPTION] [<benchmark>] [<count>]
 
   -h, --help           Display this help text.
   -b, --bench name     Name of benchmark to run.


### PR DESCRIPTION
Make people aware of `simplerunner.lua`'s existence and how they can run it.

While here, fix `simplerunner.lua`'s description of its arguments, which had an error in it, and was also a bit misleading.