### PR TITLE
Add support for benchmark build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ write the following:
 }
 ```
 
+If your benchmark requires additional building / installation, you can add an 
+executable build.sh file in your benchmark directory. If present, this will be
+run during the initial build of the entire repository. Your build.sh file is 
+responsible for determining if previous builds are present and need to be 
+replaced etc.
 
 ## Benchmarking using Krun
 

--- a/build.sh
+++ b/build.sh
@@ -99,3 +99,10 @@ if [ ${BUILDALL} ]; then
   cp lua-vermelha/luav ${ljbins}/lua-vermelha/luav
 fi
 
+echo "--------------Running benchmark build scripts-------------------------"
+
+for subdir in benchmarks/*; do
+  if [ -f "$subdir/build.sh" ]; then
+    (cd "$subdir" && ./build.sh)
+  fi
+done


### PR DESCRIPTION
The main build script was modified to run any build.sh scripts it finds in the benchmark directories and the **binary** Lua module search path now also updated for the benchmark directory.