### PR TITLE
Run each benchmark in a new sub process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ lua-vermelha/
 raptorjit_repo/
 luajit_repo/
 lastrun.json
+# Ignore any Lua rocks we installed
+/rocks/
+/benchmarks/*/rocks/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bencher_*.log
 lua-vermelha/
 raptorjit_repo/
 luajit_repo/
+lastrun.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,21 @@
 language: c
 sudo: false
 
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - liblua5.1-dev
+      - liblua5.2-dev
+      - lua5.1
+
+env:
+  global:
+    - LUAROCKS=2.4.3
+
 before_script:
+  - source .travis/setenv_lua.sh
   - ./build.sh
 
 script:
@@ -9,4 +23,4 @@ script:
   - ./builds/normal/luajit simplerunner.lua --jitstats -c 3
   - ./builds/gc64/luajit simplerunner.lua -e capnproto_decode -c 3
   - ./builds/dualnum/luajit simplerunner.lua -c 3
-  - ./builds/raptorjit/luajit simplerunner.lua -e capnproto_decode -c 3
+  - ./builds/raptorjit/luajit simplerunner.lua --inprocess -e capnproto_decode -c 3

--- a/.travis/LICENSE.txt
+++ b/.travis/LICENSE.txt
@@ -1,0 +1,23 @@
+https://github.com/moteus/lua-travis-example
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Alexey Melnichuk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.travis/platform.sh
+++ b/.travis/platform.sh
@@ -1,0 +1,15 @@
+if [ -z "${PLATFORM:-}" ]; then
+  PLATFORM=$TRAVIS_OS_NAME;
+fi
+
+if [ "$PLATFORM" == "osx" ]; then
+  PLATFORM="macosx";
+fi
+
+if [ -z "$PLATFORM" ]; then
+  if [ "$(uname)" == "Linux" ]; then
+    PLATFORM="linux";
+  else
+    PLATFORM="macosx";
+  fi;
+fi

--- a/.travis/setenv_lua.sh
+++ b/.travis/setenv_lua.sh
@@ -1,0 +1,3 @@
+export PATH=${PATH}:$HOME/.lua:$HOME/.local/bin:${TRAVIS_BUILD_DIR}/install/luarocks/bin
+bash .travis/setup_lua.sh
+eval `$HOME/.lua/luarocks path`

--- a/.travis/setup_lua.sh
+++ b/.travis/setup_lua.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+
+# A script for setting up environment for travis-ci testing.
+# Sets up Lua and Luarocks.
+# LUA must be "lua5.1", "lua5.2" or "luajit".
+# luajit2.0 - master v2.0
+# luajit2.1 - master v2.1
+
+set -eufo pipefail
+
+source .travis/platform.sh
+
+LR_HOME_DIR=$TRAVIS_BUILD_DIR/install/luarocks
+
+mkdir $HOME/.lua
+
+cd $TRAVIS_BUILD_DIR
+
+lua -v
+
+LUAROCKS_BASE=luarocks-$LUAROCKS
+
+curl --location http://luarocks.org/releases/$LUAROCKS_BASE.tar.gz | tar xz
+
+cd $LUAROCKS_BASE
+./configure --prefix="$LR_HOME_DIR"
+make build && make install
+ln -s $LR_HOME_DIR/bin/luarocks $HOME/.lua/luarocks
+
+cd $TRAVIS_BUILD_DIR
+
+luarocks --version
+
+rm -rf $LUAROCKS_BASE

--- a/build.sh
+++ b/build.sh
@@ -41,6 +41,13 @@ function copy_binaries() {
   cp ${ljsrc}/luajit ${ljbins}/$1/luajit
   cp ${ljsrc}/libluajit.so ${ljbins}/$1/libluajit.so
   cp ${ljsrc}/jit/*.lua ${ljbins}/$1/jit/
+  
+  mkdir -p ${ljbins}/$1/include/
+  cp ${ljsrc}/luaconf.h ${ljbins}/$1/include
+  cp ${ljsrc}/lua.h ${ljbins}/$1/include
+  cp ${ljsrc}/luajit.h ${ljbins}/$1/include
+  cp ${ljsrc}/lualib.h ${ljbins}/$1/include
+  cp ${ljsrc}/lauxlib.h ${ljbins}/$1/include
 }
 
 BASE_XCFLAGS=${BASE_XCFLAGS:=""}
@@ -98,6 +105,12 @@ if [ ${BUILDALL} ]; then
   cd ..
   cp lua-vermelha/luav ${ljbins}/lua-vermelha/luav
 fi
+
+# We don't have access to string functions in the config file so pass the base dir for paths
+export LUAVM_BASEDIR=$(pwd)/builds/normal
+export LUAROCKS_CONFIG=$(pwd)/rocks_config.lua
+
+luarocks --tree=rocks install https://raw.githubusercontent.com/fsfod/luachild/master/luachild-0.1-1.rockspec
 
 echo "--------------Running benchmark build scripts-------------------------"
 

--- a/rocks_config.lua
+++ b/rocks_config.lua
@@ -1,0 +1,20 @@
+lua_modules_path = "/modules"
+lib_modules_path = "/modules"
+rocks_subdir = "/packages"
+
+variables = {}
+
+if os_getenv then
+    local path = os_getenv("LUAVM_BASEDIR")
+
+    variables.LUA_BINDIR = path
+    variables.LUA_INCDIR = path.."/include"
+    variables.LUA_LIBDIR = path
+end
+
+if platform == "windows" or (platforms and platforms["windows"]) then
+    variables.LUALIB = "lua51.lib"
+else
+    variables.LUALIB = "lua51.so"
+end
+

--- a/simplerunner.lua
+++ b/simplerunner.lua
@@ -82,6 +82,7 @@ function runner.init()
     loaded = true
     oskind = runner.detectos()
     add_package_path("lualibs")
+    add_package_path("rocks/modules")
     runner.loadbenchinfo()
     
     success, jit = pcall(require, "jit")   

--- a/simplerunner.lua
+++ b/simplerunner.lua
@@ -1,6 +1,6 @@
 local jit, jit_util, jit_dump, jitstats, json
 local match, gmatch = string.match, string.gmatch
-local benchinfo, scaling, oskind
+local benchinfo, scaling, oskind, subprocess
 
 local function add_package_path(basepath)
     local ext
@@ -13,6 +13,8 @@ local function add_package_path(basepath)
     package.path = string.format("%s/?/init.lua;%s/?.lua;%s/?/?.lua;%s", basepath, basepath, basepath, package.path)
     package.cpath = string.format("%s/?.%s;%s/?/?.%s;%s", basepath, ext, basepath, ext, package.cpath)
 end
+
+ffi = require("ffi")
 
 local function table_filter(t, f)
     local result = {}
@@ -30,9 +32,26 @@ local function readfile(path)
         return false, msg
     end
 
-    local success, text = pcall(file.read, file, "*all")
-    file.close(file)  
-    return success, text
+    local result, err = file:read("*all")
+    file:close()
+    if not result then
+        return false, err
+    end
+    return true, result
+end
+
+local function writefile(path, data)
+    local file, msg = io.open(path, "w")
+    if not file then
+        return false, msg
+    end
+
+    local success, msg = file:write(data)
+    file:close()
+    if not success then
+        return false, msg
+    end
+    return true
 end
 
 local function loadjson(path)
@@ -315,21 +334,67 @@ function runner.run_benchmark_list(benchmarks, count, options)
 
     local package_path = package.path
     local package_cpath = package.cpath
-    
-    for i, name in ipairs(benchmarks) do
-        local times = runner.runbench(name, count, options.scaling or scaling[name])
-        local stats = runner.calculate_stats(times)
-        print(string.format("  Mean: %f +/- %f, min %f, max %f", stats.mean, stats.cinterval, stats.min, stats.max))
-        if jitstats then
-            jitstats.print()
-        end
-        -- Try to clean away the current benchmark and its data, so the behaviour of the GC is more predictable for the next benchmark.
-        collectgarbage("collect")
+    local results = {}
 
-        -- Restore the Lua module search path since we set it to the directory of the benchmark when we load it.
-        package.path = package_path
-        package.cpath = package_cpath
+    for i, name in ipairs(benchmarks) do
+        local scaling = options.scaling or scaling[name] or 1
+        local stats
+
+        if options.inprocess then
+            local times, jstats = runner.runbench(name, count, scaling)
+            stats = runner.calculate_stats(times)
+            stats.times = times
+            print("  " .. runner.fmtstats(stats))
+            if jitstats then
+                stats.jitstats = jstats
+                jitstats.print()
+            end
+        else
+           runner.runbench_outprocess(name, count, scaling, options)
+        end
+
+        if options.inprocess then
+            -- Try to clean away the current benchmark and its data, so the behaviour of the GC is more predictable for the next benchmark.
+            collectgarbage("collect")
+
+            -- Restore the Lua module search path since we set it to the directory of the benchmark when we load it.
+            package.path = package_path
+            package.cpath = package_cpath
+        end
     end
+end
+
+function runner.runbench_outprocess(name, count, scaling, options)
+    local lc = require("luachild")
+    local read, write = lc.pipe()
+
+    local p = lc.spawn{
+        command = arg[-1],
+        args = {
+            arg[0], "--childprocess", name, count, scaling, unpack(arg, 1) 
+        },
+    }
+ 
+    local cmdret = p:wait()
+    if cmdret ~= 0 then
+        error("Out of process benchmark execution failed status = "..cmdret)
+    end
+end
+
+function runner.subprocess_run(benchmark, count, scaling, parent_options)
+    scaling = tonumber(scaling)
+    count = tonumber(count)
+    subprocess = true
+    runner.processoptions(parent_options)
+
+    local times, jstats = runner.runbench(benchmark, count, scaling)
+    local stats = runner.calculate_stats(times)
+    print("  " .. runner.fmtstats(stats))
+    if jitstats then
+        jitstats.print()
+    end
+
+    os.exit(0)
 end
 
 function runner.calculate_stats(times)
@@ -358,6 +423,10 @@ function runner.calculate_stats(times)
     -- 95% confidence interval
     stats.cinterval = 1.960 * stats.stddev/math.sqrt(count)
     return stats
+end
+
+function runner.fmtstats(stats)
+    return string.format("Mean: %f +/- %f, min %f, max %f", stats.mean, stats.cinterval, stats.min, stats.max)
 end
 
 -- Command line parsing system mostly copied from dynasm.lua in LuaJIT
@@ -404,17 +473,18 @@ function opt_map.help()
 
 Usage: simplerunner [OPTION] [<benchmark>] [<count>]
 
-  -h, --help           Display this help text.
-  -b, --bench name     Name of benchmark to run.
-  -c, --count num      Number of times to run the benchmarks.
-  -s, --scaling num    Number of interations to run the benchmarks.
-  -e, --exclude name   Exclude a benchmark from being run.
+  -h, --help            Display this help text.
+  -b, --bench name      Name of benchmark to run.
+  -c, --count num       Number of times to run the benchmarks.
+  -s, --scaling num     Number of interations to run the benchmarks.
+  -e, --exclude name    Exclude a benchmark from being run.
 
   --jitstats           Collect and print jit statisitcs from running the benchmarks.
   --jdump options      Run LuaJIT's jit.dump module with the specifed options.
   --benchloadjitstats  Also collect jitstats when loading a benchmark
   --nogc               Run the benchmarks with the GC disabled.
   --norandomize        Don't randomize the run order of the benchmarks.
+  --inprocess          Run benchmarks in the main process instead of executing them in a child process.
 ]]
     os.exit(0)
 end
@@ -428,6 +498,7 @@ function opt_map.jitstats() g_opt.jitstats = true end
 function opt_map.benchloadjitstats() loading_jitstats = true end
 function opt_map.nogc() g_opt.nogc = true end
 function opt_map.norandomize() g_opt.norandomize = true end
+function opt_map.inprocess() g_opt.inprocess = true end
 function opt_map.jdump(args)
     local options = optparam(args)
     local outfile = options:find(",")
@@ -455,7 +526,6 @@ end
 -- Parse arguments.
 function runner.parse_commandline(args)
     -- Default options.
-    g_opt.count = 30
     g_opt.benchmarks = {}
     g_opt.excludes = {}
     -- Process all option arguments.
@@ -483,6 +553,8 @@ function runner.parse_commandline(args)
         end
     end
 
+    g_opt.count = g_opt.count or 30
+
     local benchmarks
     if #g_opt.benchmarks > 0 then
         benchmarks = g_opt.benchmarks
@@ -505,6 +577,11 @@ function runner.parse_commandline(args)
 end
 
 function runner.processoptions(options)
+    -- Don't pointlessly run these options in the main process if we're running benchmarks in a child process
+    if not subprocess and not options.inprocess then
+        return
+    end
+
     if options.jitstats then
         runner.load_jitstats()
     end
@@ -552,12 +629,17 @@ end
 
 runner.init()
 
-if arg[1] then
+if arg[1] == "--childprocess" then
+    local benchmark, count, scaling = unpack(arg, 2)
+    local _, options = runner.parse_commandline({unpack(arg, 5)})
+    runner.subprocess_run(benchmark, count, scaling, options)
+else
     local benchmarks, options = runner.parse_commandline(arg)
     runner.processoptions(options)
+
+    if not arg[1] then
+        benchmarks = benchlist
+    end
     benchmarks = runner.filter_benchmarks(benchmarks)
     runner.run_benchmark_list(benchmarks, options.count, options)
-else
-    local benchmarks = runner.filter_benchmarks(benchlist)
-    runner.run_benchmark_list(benchmarks, 30)
 end


### PR DESCRIPTION
Run each benchmark in a new sub process that writes its results out to a temporary json file that the main process reads back in and prints the stats for it. To simplify debugging benchmarks there is an new option to run them in process like before.
There is also now a command line option to save all the benchmark results to a json file including the options were used to generate them which also includes benchmark scaling values.
