### PR TITLE
Exclude some of the long running scimark benchmarks from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   - ./build.sh
 
 script:
-  - ./builds/nojit/luajit simplerunner.lua -c 1
+  - ./builds/nojit/luajit simplerunner.lua -c 1 -e scimark_fft -e scimark_sparse -e scimark_sor -e scimark_lu -e mandelbrot_bit
   - ./builds/normal/luajit simplerunner.lua --jitstats -c 3
   - ./builds/gc64/luajit simplerunner.lua -e capnproto_decode -c 3
   - ./builds/dualnum/luajit simplerunner.lua -c 3


### PR DESCRIPTION
The scimark benchmarks are taking 15-38 seconds each when running under nojit builds for travis just exclude them just for nojit builds to help shorten travis run time.