### PR TITLE
Add a benchmark based on lua-resty-json 

### DIFF
--- a/benchinfo.json
+++ b/benchinfo.json
@@ -38,6 +38,7 @@
     "scimark_mc" : 13000000,
     "revcomp" : 45,
     "moonscript" : 1,
+    "resty_json" : 450,
   },
 
   "info" : {

--- a/benchmarks/resty_json/.gitignore
+++ b/benchmarks/resty_json/.gitignore
@@ -1,0 +1,3 @@
+libljson.so
+json_decoder.lua
+repo/

--- a/benchmarks/resty_json/bench.lua
+++ b/benchmarks/resty_json/bench.lua
@@ -1,0 +1,13 @@
+local ljson_decoder = require"json_decoder"
+local instance = ljson_decoder.new()
+
+local luafile = io.open("benchdata/simpledata.json", "rb")
+local text = luafile:read("*all")
+luafile:close()
+
+function run_iter(count)
+    for n=1, count do
+        local result, err = instance:decode(text)
+        assert(result and not err)
+    end
+end

--- a/benchmarks/resty_json/build.sh
+++ b/benchmarks/resty_json/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+git clone https://github.com/cloudflare/lua-resty-json repo
+cd repo
+git checkout 547c34da77ab96bcf60a829243179b90b7f30459
+make
+cp libljson.so ..
+cp json_decoder.lua ..

--- a/luajit.krun
+++ b/luajit.krun
@@ -118,6 +118,7 @@ BENCHMARKS = {
     "scimark_mc" : 13000000,
     "revcomp" : 45,
     "moonscript" : 1,
+    "resty_json" : 450,
 }
 
 # list of "bench:vm:variant"


### PR DESCRIPTION
Add a benchmark based [lua-resty-json](https://github.com/cloudflare/lua-resty-json) a json decoder that partially parses json in an external shared library. The shared library returns a flat array of parsed token values that processed by Lua code in to Lua tables in i think bottom up process. 
This benchmark also make heavy use of cdata and FFI compared compared to a lot of our other benchmarks.