### PR TITLE
Add some benchmarks based on various Lua implementations of sorting algorithms 

### DIFF
--- a/benchinfo.json
+++ b/benchinfo.json
@@ -39,6 +39,10 @@
     "revcomp" : 45,
     "moonscript" : 1,
     "resty_json" : 450,
+    "quicksort" : 1000000,
+    "table_cmpsort" : 100000,
+    "radixsort" : 1000000,
+    "heapsort" : 1000000,
   },
 
   "info" : {
@@ -47,5 +51,6 @@
     "jsonlua_encode" : { "ffirequired" : true },
     "jsonlua_decode" : { "ffirequired" : true },
     "luafun" : { "ffirequired" : true },
+    "radixsort" : { "ffirequired" : true },
   }
 }

--- a/benchmarks/heapsort/bench.lua
+++ b/benchmarks/heapsort/bench.lua
@@ -1,0 +1,32 @@
+local array_generator = require("array_generator")
+local hsort = require"heapsort"
+require("table.new")
+
+local function cmp(a, b)
+  return a > b
+end
+
+local list
+
+function run_iter(n)
+  if not list then
+    list = table.new(n, 0)
+  end
+
+  array_generator.fill_random_int(list, n)
+  local result = hsort(list, cmp, n)
+  assert(result[1] <= result[2])
+  assert(result[n-2] <= result[n-1])
+
+  array_generator.fill_sorted(list, n)
+  result = hsort(list, cmp, n)
+  assert(result[1] <= result[2])
+  assert(result[n-2] <= result[n-1])
+
+  array_generator.fill_reverse_sorted(list, n)
+  result = hsort(list, cmp, n)
+  assert(result[1] <= result[2])
+  assert(result[n-2] <= result[n-1])
+
+  return
+end

--- a/benchmarks/heapsort/heapsort.lua
+++ b/benchmarks/heapsort/heapsort.lua
@@ -1,0 +1,91 @@
+-- Heap sort implementation from http://www.algorithm.zone/implementation/288/heap-sort/yonaba/lua/
+-- See: http://en.wikipedia.org/wiki/Heapsort
+
+-- Binary heap data structure implementation
+-- Based on http://github.com/Yonaba/Binary-Heaps
+
+-- Percolates up
+local function sift_up(heap, index)
+  if index == 1 then return end
+  local pIndex
+  if index <= 1 then return end
+  if index % 2 == 0 then
+    pIndex =  index / 2
+  else pIndex = (index - 1) / 2
+  end
+  if not heap._sort(heap._array[pIndex], heap._array[index]) then
+    heap._array[pIndex], heap._array[index] = heap._array[index], heap._array[pIndex]
+    sift_up(heap, pIndex)
+  end
+end
+
+-- Percolates down
+local function sift_down(heap,index)
+  local lfIndex,rtIndex,minIndex
+  lfIndex = 2 * index
+  rtIndex = lfIndex + 1
+  if rtIndex > heap.size then
+    if lfIndex > heap.size then return
+    else minIndex = lfIndex
+    end
+  else
+    if heap._sort(heap._array[lfIndex],heap._array[rtIndex]) then
+      minIndex = lfIndex
+    else minIndex = rtIndex
+    end
+  end
+  if not heap._sort(heap._array[index],heap._array[minIndex]) then
+    heap._array[index], heap._array[minIndex] = heap._array[minIndex], heap._array[index]
+    sift_down(heap, minIndex)
+  end
+end
+
+-- Default comparison function
+local function f_min(a,b) return a < b end
+
+-- Returns a new binary heap
+local function newHeap(comp)
+  return {_array = {}, _sort = comp or f_min, size = 0}
+end
+
+-- Checks if the heap is empty
+function isEmpty(heap) return heap.size == 0 end
+
+-- Adds a new value in the heap
+-- Note, we could have also implemented a heapify method
+-- push all the values and then restore the heap property
+local function pushArray(heap, array)
+  local size = heap.size
+  for i, value in ipairs(array) do
+    size = size + 1
+    heap._array[size] = value
+    heap.size = size
+    sift_up(heap, size)
+  end
+  return heap
+end
+
+-- Pops values from the heap
+local function popArray(heap, array)
+  local count = 1
+  array = array or {}
+  while not isEmpty(heap) do
+    local root
+    if heap.size > 0 then
+      root = heap._array[1]
+      heap._array[1] = heap._array[heap.size]
+      heap._array[heap.size] = nil
+      heap.size = heap.size - 1
+      if heap.size > 1 then sift_down(heap, 1) end
+    end
+    array[heap.size + 1] = root
+  end
+  return array
+end
+
+return function(array, comp, size)
+  if (size or #array) <= 1 then 
+    return {array[1]} 
+  end
+  return popArray(pushArray(newHeap(comp), array))
+end

--- a/benchmarks/quicksort/bench.lua
+++ b/benchmarks/quicksort/bench.lua
@@ -1,0 +1,30 @@
+local array_generator = require("array_generator")
+local qsort = require"qsort"
+require("table.new")
+
+local function cmp(a, b)
+  return a < b
+end
+
+function run_iter(n)
+  if not list then
+    list = table.new(n, 0)
+  end
+
+  array_generator.fill_random_int(list, n)
+  qsort(list, cmp, n)
+  assert(list[1] <= list[2])
+  assert(list[n-2] <= list[n-1])
+
+  array_generator.fill_sorted(list, n)
+  qsort(list, cmp, n)
+  assert(list[1] <= list[2])
+  assert(list[n-2] <= list[n-1])
+
+  array_generator.fill_reverse_sorted(list, n)
+  qsort(list, cmp, n)
+  assert(list[1] <= list[2])
+  assert(list[n-2] <= list[n-1])
+
+  return
+end

--- a/benchmarks/quicksort/qsort.lua
+++ b/benchmarks/quicksort/qsort.lua
@@ -1,0 +1,127 @@
+-- Copyright (C) 2017 - DarkRoku12
+-- https://github.com/DarkRoku12/lua_sort
+-- Optimized version.
+
+-- Stack slot #1 = t.
+local function set2( t , i , j , ival , jval )
+   t[ i ] = ival ; -- lua_rawseti(L, 1, i);
+   t[ j ] = jval ; -- lua_rawseti(L, 1, j);
+end
+
+local function default_comp( a , b )
+   return a < b
+end
+
+local auxsort ;
+
+function auxsort( t , l , u , sort_comp )
+
+   while l < u do 
+
+      -- sort elements a[l], a[(l+u)/2] and a[u]
+
+      do
+         local a = t[ l ] -- lua_rawgeti(L, 1, l);
+         local b = t[ u ] -- lua_rawgeti(L, 1, u);
+
+         if sort_comp( b , a ) then
+            set2( t , l , u , b , a ) -- /* swap a[l] - a[u] */
+         end
+      end
+
+      if u - l == 1 then break end -- only 2 elements
+
+      local i = math.floor( ( l + u ) / 2 ) ; -- -- for tail recursion (i).
+
+      do
+         local a = t[ i ] -- lua_rawgeti(L, 1, i);
+         local b = t[ l ] -- lua_rawgeti(L, 1, l);
+
+         if sort_comp( a , b ) then -- a[i] < a[l] ?
+            set2( t , i , l , b , a )
+         else
+            b = nil -- remove a[l]
+            b = t[ u ]
+            if sort_comp( b , a ) then -- a[u]<a[i] ?
+               set2( t , i , u , b , a )
+            end
+         end
+      end
+
+      if u - l == 2 then break end ; -- only 3 elements
+
+      local P = t[ i ] -- Pivot.
+      local P2 = P -- lua_pushvalue(L, -1);
+      local b = t[ u - 1 ]
+
+      set2( t , i , u - 1 , b , P2 )
+      -- a[l] <= P == a[u-1] <= a[u], only need to sort from l+1 to u-2 */
+
+      i = l ;
+
+      local j = u - 1 ; -- for tail recursion (j).
+
+      while true do -- for( ; ; )
+         -- invariant: a[l..i] <= P <= a[j..u]
+         -- repeat ++i until a[i] >= P
+
+         i = i + 1 ; -- ++i
+         local a = t[ i ] -- lua_rawgeti(L, 1, i)
+
+         while sort_comp( a , P ) do
+            i = i + 1 ; -- ++i
+            a = t[ i ] -- lua_rawgeti(L, 1, i)
+         end
+
+         -- repeat --j until a[j] <= P
+
+         j = j - 1 ; -- --j
+         local b = t[ j ]
+
+         while sort_comp( P , b ) do
+            j = j - 1 ; -- --j
+            b = t[ j ] -- lua_rawgeti(L, 1, j)
+         end
+
+         if j < i then
+            break
+         end
+
+         set2( t , i , j , b , a )
+      end -- End for.
+
+      t[ u - 1 ] , t[ i ] = t[ i ] , t[ u - 1 ] ;
+
+      -- a[l..i-1] <= a[i] == P <= a[i+1..u] */
+      -- adjust so that smaller half is in [j..i] and larger one in [l..u] */
+
+      if ( i - l ) < ( u - i ) then
+         j = l ;
+         i = i - 1 ;
+         l = i + 2 ;
+      else
+         j = i + 1 ;
+         i = u ;
+         u = j - 2 ;
+      end
+
+      auxsort( t , j , i , sort_comp ) ;  -- call recursively the smaller one */
+
+   end
+   -- end of while
+   -- repeat the routine for the larger one
+  return
+end
+
+-- sort function.
+return function( t , comp, len )
+
+   --assert( type( t ) == "table" )
+
+   if comp then
+      assert( type( comp ) == "function" )
+   end
+
+   auxsort( t , 1 , len or #t , comp or default_comp )
+
+end

--- a/benchmarks/radixsort/bench.lua
+++ b/benchmarks/radixsort/bench.lua
@@ -1,0 +1,65 @@
+-- LSD radix sort implementation based on code from http://www.osix.net/modules/article/?id=704
+local array_generator = require("array_generator")
+local band, rshift = bit.band, bit.rshift
+
+local mask = 0xff
+local counts_size = 256
+local counts = ffi.new("int32_t[?]", counts_size)
+
+local function count_mask(list, n, shift)
+  ffi.fill(counts, counts_size * 4, 0)
+  for i = 0, n-1 do
+    local index = band(rshift(list[i], shift), mask)
+    counts[index] = counts[index] + 1
+  end
+end
+
+local prefix_sums = ffi.new("int32_t[?]", counts_size, {0})
+
+local function radixsort(list, size)
+  local temp = ffi.new("int64_t[?]", size)
+  local shift = 0
+
+  for n = 0, 7 do
+    count_mask(list, size, shift)
+
+    prefix_sums[0] = 0
+    for i = 1, counts_size-1 do
+      prefix_sums[i] = prefix_sums[i-1] + counts[i-1]
+    end
+
+    for i = 0, size-1 do
+      local bin = band(rshift(list[i], shift), mask)
+      local index = prefix_sums[bin]
+      prefix_sums[bin] = index + 1
+      temp[index] = list[i]
+    end
+
+    ffi.copy(list, temp, size * 8)
+    shift = shift + 8
+  end
+end
+
+local list
+
+function run_iter(n)
+  if not list then
+    list = ffi.new("int64_t[?]", n)
+  end
+  array_generator.fill_random_int(list, n)
+  radixsort(list, n)
+  assert(list[0] <= list[1])
+  assert(list[n-2] <= list[n-1])
+  
+  array_generator.fill_sorted(list, n)
+  radixsort(list, n)
+  assert(list[0] <= list[1])
+  assert(list[n-2] <= list[n-1])
+
+  array_generator.fill_reverse_sorted(list, n)
+  radixsort(list, n)
+  assert(list[0] <= list[1])
+  assert(list[n-2] <= list[n-1])
+
+  return
+end

--- a/benchmarks/table_cmpsort/bench.lua
+++ b/benchmarks/table_cmpsort/bench.lua
@@ -1,0 +1,29 @@
+local array_generator = require("array_generator")
+require("table.new")
+
+local function cmp(a, b)
+  return a < b
+end
+
+function run_iter(n)
+  if not list then
+    list = table.new(n, 0)
+  end
+
+  array_generator.fill_random_int(list, n)
+  table.sort(list, cmp)
+  assert(list[1] <= list[2])
+  assert(list[n-2] <= list[n-1])
+
+  array_generator.fill_sorted(list, n)
+  table.sort(list, cmp)
+  assert(list[1] <= list[2])
+  assert(list[n-2] <= list[n-1])
+
+  array_generator.fill_reverse_sorted(list, n)
+  table.sort(list, cmp)
+  assert(list[1] <= list[2])
+  assert(list[n-2] <= list[n-1])
+
+  return
+end

--- a/luajit.krun
+++ b/luajit.krun
@@ -119,6 +119,10 @@ BENCHMARKS = {
     "revcomp" : 45,
     "moonscript" : 1,
     "resty_json" : 450,
+    "quicksort" : 1000000,
+    "table_cmpsort" : 100000,
+    "radixsort" : 1000000,
+    "heapsort" : 1000000,
 }
 
 # list of "bench:vm:variant"

--- a/lualibs/array_generator.lua
+++ b/lualibs/array_generator.lua
@@ -1,0 +1,72 @@
+local random = math.random
+local lib = {
+  randomseed = 2654435761,
+}
+
+local function check_args(list, size, start, stop)
+  if type(list) == "table" then
+    size = size or #list
+    start = start or 1
+    stop = stop or size
+  else
+    assert(type(list) == "cdata")
+    assert(size > 0, "bad list size")
+    start = start or 0
+    stop = stop or size-1
+  end
+  assert(size ~= 0)
+  return start, stop, size
+end
+
+function lib.fill_sorted(list, size)
+  local start, stop
+  start, stop, size = check_args(list, size)
+  for i = start, stop do
+    list[i] = i
+  end
+end
+
+function lib.fill_reverse_sorted(list, size)
+  local start, stop
+  start, stop, size = check_args(list, size)
+  for i = start, stop do
+    list[i] = size-i
+  end
+end
+
+function lib.fill_random(list, size)
+  local start, stop
+  start, stop, size = check_args(list, size)
+  math.randomseed(lib.randomseed)
+  for i = start, stop do
+    list[i] = random()
+  end
+end
+
+function lib.fill_random_int(list, size)
+  local start, stop
+  start, stop, size = check_args(list, size)
+  math.randomseed(lib.randomseed)
+  for i = start, stop do
+    list[i] = random(0xFFFFFFF)
+  end
+end
+
+function lib.fill_random_int64(list, size)
+  local start, stop
+  start, stop, size = check_args(list, size)
+  math.randomseed(lib.randomseed)
+  for i = start, stop do
+    list[i] = random(281474976710655)
+  end
+end
+
+function lib.assert_sorted(list, size, start, stop)
+  start, stop, size = check_args(list, size, start, stop)
+  for i = start, stop-1 do
+    if list[i] > list[i+1] then
+      error(string.format("List not sorted at index %d = [-1]: %s, [i]: %s, [i+1]%s", i, list[i-1], list[i], list[i+1]))
+    end
+  end
+end
+return lib


### PR DESCRIPTION
Adds some benchmarks for quick sort, heap sort and radix sort along one of the built-in table.sort to compare against.

The benchmarks are each passed a Lua table of numbers in random, reverse sorted and sorted order.
The quick sort library is based on the C code of the built-in table sort ported to Lua.
Radix sort is mostly a pure cdata based design that sorts 64 bit ints from a cdata array but it could maybe sort doubles like the others by using a few bit operations.