### PR TITLE
Update Raptorjit commit lock

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Make sure we bail out if any of our commands fail, like the commit lock
+set -e
+
 #Build the various interesting flavours of LuaJIT
 if [ $# -gt 1 ]; then
   echo "Usage: build.sh [<LuaJIT source dir>]" 2>&1

--- a/commitlock.txt
+++ b/commitlock.txt
@@ -1,2 +1,2 @@
-luajit_commitid=655d8f29ae0a3c4cd1c57c6c8c88e6be41aed21c
+luajit_commitid=a6e64201a043c397f43f10eab9fef2f02adf88e5
 raptorjit_commitid=39680ca7ebc3ce43f68c465bedb3e88f074aaeea

--- a/commitlock.txt
+++ b/commitlock.txt
@@ -1,2 +1,2 @@
 luajit_commitid=a6e64201a043c397f43f10eab9fef2f02adf88e5
-raptorjit_commitid=39680ca7ebc3ce43f68c465bedb3e88f074aaeea
+raptorjit_commitid=5d235e6e315b0507b207c7e1f0c14a50166a1371

--- a/luajit.krun
+++ b/luajit.krun
@@ -125,6 +125,8 @@ BENCHMARKS = {
 SKIP = [
     "capnproto_decode:GC64:*", # Sometime crashes with GC64
     "capnproto_decode:RaptorJIT:*", # Sometimes crashes as well
+	# We can't use binary Lua modules with Raptorjit because it statically links the Lua shared library
+    "moonscript:RaptorJIT:*",
     #"*:Normal:*",
     #"*:GC64:*",
     #"*:NoJIT:*",


### PR DESCRIPTION
Fix the broken LuaJIT commit lock and update the raptorjit one to  v1.0.0alpha1 that was just recently released. The main build script was changed to abort if any of it commands return non zero.
Also exclude the moonscript benchmark for raptorjit since there is no lua51.so built by raptorjit needed for the binary Lua modules used by the benchmark.